### PR TITLE
make_random_password(): avoid modulo bias, and do not deplete system entropy

### DIFF
--- a/builder/builder.ml
+++ b/builder/builder.ml
@@ -456,6 +456,14 @@ let main () =
         Char.code s.[0]
     in
 
+    (* return a random number uniformly distributed in [0, upper_bound)
+     * avoiding modulo bias *)
+    let rec uniform_random read upper_bound =
+      let c = read () in
+      if c >= 256 mod upper_bound then c mod upper_bound
+      else uniform_random read upper_bound
+    in
+
     let make_random_password () =
       (* Get random characters from the set [A-Za-z0-9] with some
        * homoglyphs removed.
@@ -467,7 +475,7 @@ let main () =
       let fd = openfile "/dev/urandom" [O_RDONLY] 0 in
       let buf = String.create 16 in
       for i = 0 to 15 do
-        buf.[i] <- chars.[read_byte fd () mod nr_chars]
+        buf.[i] <- chars.[uniform_random (read_byte fd) nr_chars]
       done;
       close fd;
 


### PR DESCRIPTION
Following the link to builder.ml from your blogpost I noticed the make_random_password () function, and I have some suggestions, well nitpicks really. See the 2 commits from this pull request.
1. Using Ocaml's buffered I/O means that one make_random_password() call reads 64k bytes from /dev/urandom which drops the system's entropy to minimum ~128 bits. The fix is to use unbuffered I/O from the Unix module.
2. There is a modulo bias when generating the random password: [0,256) mod 60 won't give you uniformly distributed bytes. In this particular case it probably doesn't matter, but you never know when someone copy+pastes your code into their project thinking this is a proper way to generate random passwords, so IMHO its best to avoid the modulo bias.
   See here for more details: http://eternallyconfuzzled.com/arts/jsw_art_rand.aspx
   And see arc4random_uniform's implementation: http://www.openbsd.org/cgi-bin/cvsweb/src/lib/libc/crypt/arc4random.c?rev=1.26;content-type=text%2Fplain
3. The generated password needs ~2^107 brute-force attempts (16 \* log2(60) + log2(default_rounds=5000)), which is more than enough of course, but usually 128-bit strength is used for keys. A password length of 20 characters would achieve that. My pull request doesn't include this change, its up to you.
