### PR TITLE
remove non-portable chmod from libtool-kill-dependency_libs.sh

### DIFF
--- a/libtool-kill-dependency_libs.sh
+++ b/libtool-kill-dependency_libs.sh
@@ -51,10 +51,9 @@ done
 "${args[@]}"
 
 if [ -n "$output" ]; then
-    mv "$output" "$output.tmp"
+    cp -p "$output" "$output.tmp"
 
     # Remove dependency_libs from output.
     sed "s/^dependency_libs=.*/dependency_libs=''/" < "$output.tmp" > "$output"
-    chmod --reference="$output.tmp" "$output"
     rm "$output.tmp"
 fi


### PR DESCRIPTION
`chmod --reference` is not available on Mac OS X. 

Keeping the original file and directing edits into it preserves permissions and removes the need to chmod.

(Tried `sed -i` for inplace editing but unfortunately it isn't portable either.)
