### PR TITLE
use pkg-config to look up ncurses

### DIFF
--- a/builder/Makefile.am
+++ b/builder/Makefile.am
@@ -24,7 +24,8 @@ AM_CFLAGS = \
 	-I$(top_srcdir)/src \
 	-I$(top_srcdir)/fish \
 	-pthread \
-	$(LIBLZMA_CFLAGS)
+	$(LIBLZMA_CFLAGS) \
+	$(LIBCURSES_CFLAGS)
 
 EXTRA_DIST = \
 	$(SOURCES) \
@@ -172,7 +173,7 @@ OCAMLCLIBS  = \
 	-L../src/.libs -lutils \
 	-L../gnulib/lib/.libs -lgnu \
 	-pthread -lpthread \
-	-ltinfo -lcrypt
+	$(LIBCURSES_LIBS) -lcrypt
 
 if HAVE_OCAMLOPT
 virt-builder: $(OBJECTS)

--- a/configure.ac
+++ b/configure.ac
@@ -352,19 +352,13 @@ struct sockaddr_un myaddr;
     AC_DEFINE_UNQUOTED([UNIX_PATH_MAX], $unix_path_max, [Custom value for UNIX_PATH_MAX])
   ])
 
-dnl tgetent, tputs and UP [sic] are all required.  They come from libtinfo
-dnl which is pulled in as a dependency of libncurses.
-old_LIBS="$LIBS"
-AC_CHECK_LIB([tinfo], [tgetent], [], [
-    AC_MSG_ERROR(['libtinfo' library (usually part of ncurses) not found, or it doesn't contain 'tgetent'])
+dnl tgetent, tputs and UP [sic] are all required.  They come from the lower
+dnl tinfo library, but might be part of ncurses directly.
+PKG_CHECK_MODULES([LIBCURSES], [tinfo], [], [
+    PKG_CHECK_MODULES([LIBCURSES], [ncurses])
 ])
-AC_CHECK_LIB([tinfo], [tputs], [], [
-    AC_MSG_ERROR(['libtinfo' library (usually part of ncurses) not found, or it doesn't contain 'tputs'])
-])
-AC_CHECK_LIB([tinfo], [UP], [], [
-    AC_MSG_ERROR(['libtinfo' library (usually part of ncurses) not found, or it doesn't contain 'UP'])
-])
-LIBS="$old_LIBS"
+AC_SUBST([LIBCURSES_CFLAGS])
+AC_SUBST([LIBCURSES_LIBS])
 
 dnl GNU gettext tools (optional).
 AC_CHECK_PROG([XGETTEXT],[xgettext],[xgettext],[no])

--- a/customize/Makefile.am
+++ b/customize/Makefile.am
@@ -124,7 +124,7 @@ OCAMLCFLAGS = $(OCAML_FLAGS) $(OCAML_WARN_ERROR) $(OCAMLPACKAGES)
 OCAMLOPTFLAGS = $(OCAMLCFLAGS)
 
 OCAMLCLIBS  = \
-	$(LIBXML2_LIBS) $(LIBINTL) -ltinfo -lcrypt \
+	$(LIBXML2_LIBS) $(LIBINTL) $(LIBCURSES_LIBS) -lcrypt \
 	-L../src/.libs -lutils \
 	-L../gnulib/lib/.libs -lgnu
 

--- a/mllib/Makefile.am
+++ b/mllib/Makefile.am
@@ -99,7 +99,7 @@ OCAMLCFLAGS = $(OCAML_FLAGS) $(OCAML_WARN_ERROR) $(OCAMLPACKAGES)
 OCAMLOPTFLAGS = $(OCAMLCFLAGS)
 
 OCAMLCLIBS  = \
-	$(LIBXML2_LIBS) $(LIBINTL) -ltinfo -lcrypt \
+	$(LIBXML2_LIBS) $(LIBINTL) $(LIBCURSES_LIBS) -lcrypt \
 	-L../src/.libs -lutils \
 	-L../gnulib/lib/.libs -lgnu
 
@@ -154,11 +154,11 @@ check_SCRIPTS = common_utils_tests
 if HAVE_OCAMLOPT
 common_utils_tests: common_gettext.cmx tty-c.o tTY.cmx common_utils.cmx common_utils_tests.cmx
 	$(OCAMLFIND) ocamlopt $(OCAMLOPTFLAGS) \
-	  mlguestfs.cmxa -linkpkg $^ -cclib -ltinfo -o $@
+	  mlguestfs.cmxa -linkpkg $^ -cclib $(LIBCURSES_LIBS) -o $@
 else
 common_utils_tests: common_gettext.cmo tty-c.o tTY.cmo common_utils.cmo common_utils_tests.cmo
 	$(OCAMLFIND) ocamlc $(OCAMLCFLAGS) \
-	  mlguestfs.cma -linkpkg $^ -cclib -ltinfo -custom -o $@
+	  mlguestfs.cma -linkpkg $^ -cclib $(LIBCURSES_LIBS) -custom -o $@
 endif
 
 TESTS_ENVIRONMENT = $(top_builddir)/run --test

--- a/resize/Makefile.am
+++ b/resize/Makefile.am
@@ -71,7 +71,7 @@ OCAMLCFLAGS = $(OCAML_FLAGS) $(OCAML_WARN_ERROR) $(OCAMLPACKAGES)
 OCAMLOPTFLAGS = $(OCAMLCFLAGS)
 
 OCAMLCLIBS  = \
-	$(LIBXML2_LIBS) $(LIBINTL) -ltinfo \
+	$(LIBXML2_LIBS) $(LIBINTL) $(LIBCURSES_LIBS) \
 	-L../src/.libs -lutils \
 	-L../gnulib/lib/.libs -lgnu
 

--- a/sparsify/link.sh.in
+++ b/sparsify/link.sh.in
@@ -19,4 +19,4 @@
 # Hack automake to link binary properly.  There is no other way to add
 # the -cclib parameter to the end of the command line.
 
-exec "$@" -linkpkg -cclib '-ltinfo'
+exec "$@" -linkpkg -cclib '@LIBCURSES_LIBS@'

--- a/sysprep/Makefile.am
+++ b/sysprep/Makefile.am
@@ -136,7 +136,7 @@ OCAMLCFLAGS = $(OCAML_FLAGS) $(OCAML_WARN_ERROR) $(OCAMLPACKAGES)
 OCAMLOPTFLAGS = $(OCAMLCFLAGS)
 
 OCAMLCLIBS  = \
-	$(LIBXML2_LIBS) $(LIBINTL) -ltinfo -lcrypt \
+	$(LIBXML2_LIBS) $(LIBINTL) $(LIBCURSES_LIBS) -lcrypt \
 	-L../src/.libs -lutils \
 	-L../gnulib/lib/.libs -lgnu
 

--- a/v2v/link.sh.in
+++ b/v2v/link.sh.in
@@ -19,4 +19,4 @@
 # Hack automake to link binary properly.  There is no other way to add
 # the -cclib parameter to the end of the command line.
 
-exec "$@" -linkpkg -cclib '-lutils -ltinfo -lcrypt @LIBVIRT_LIBS@ @LIBXML2_LIBS@ @LIBINTL@ -lgnu'
+exec "$@" -linkpkg -cclib '-lutils @LIBCURSES_LIBS@ -lcrypt @LIBVIRT_LIBS@ @LIBXML2_LIBS@ @LIBINTL@ -lgnu'


### PR DESCRIPTION
Hardcoding -ltinfo breaks on distros that do not build the sep library
(which is the default ncurses behavior).  Use pkg-config to look up the
right libraries regardless of how the distro built things.

Note: I haven't fully tested this due to all the package dependencies.  I verified the configure parts look sane at least :).
