### PR TITLE
Addition to docs for building from Git

### DIFF
--- a/docs/guestfs-building.pod
+++ b/docs/guestfs-building.pod
@@ -403,6 +403,7 @@ Optional.  Library for filesystem forensics analysis.
 
 =head1 BUILDING FROM GIT
 
+ sudo dnf install gettext-debel
  git clone https://github.com/libguestfs/libguestfs
  cd libguestfs
  ./autogen.sh


### PR DESCRIPTION
Building from Git requires *gettext-devel* to be installed for the `./autogen.sh` step to complete.