### PR TITLE
Fixed work with mounted iso

### DIFF
--- a/generator/actions_core.ml
+++ b/generator/actions_core.ml
@@ -210,7 +210,7 @@ this function fails and the C<errno> is set to C<EINVAL>." };
 
   { defaults with
     name = "add_drive"; added = (0, 0, 3);
-    style = RErr, [String (PlainString, "filename")], [OBool "readonly"; OString "format"; OString "iface"; OString "name"; OString "label"; OString "protocol"; OStringList "server"; OString "username"; OString "secret"; OString "cachemode"; OString "discard"; OBool "copyonread"];
+    style = RErr, [String (PlainString, "filename")], [OBool "readonly"; OString "format"; OString "iface"; OString "name"; OString "label"; OString "protocol"; OStringList "server"; OString "username"; OString "secret"; OString "cachemode"; OString "discard"; OBool "copyonread"; OString "device"];
     once_had_no_optargs = true;
     blocking = false;
     fish_alias = ["add"];

--- a/lib/drives.c
+++ b/lib/drives.c
@@ -58,6 +58,7 @@ struct drive_create_data {
   const char *cachemode;
   enum discard discard;
   bool copyonread;
+  enum device device;
 };
 
 COMPILE_REGEXP (re_hostname_port, "(.*):(\\d+)$", 0)
@@ -114,6 +115,7 @@ create_drive_file (guestfs_h *g,
   drv->cachemode = data->cachemode ? safe_strdup (g, data->cachemode) : NULL;
   drv->discard = data->discard;
   drv->copyonread = data->copyonread;
+  drv->device = data->device;
 
   if (data->readonly) {
     if (create_overlay (g, drv) == -1) {
@@ -436,6 +438,7 @@ create_drive_dev_null (guestfs_h *g,
   data->exportname = tmpfile;
   data->discard = discard_disable;
   data->copyonread = false;
+  data->device = device_disk;
 
   return create_drive_file (g, data);
 }
@@ -762,6 +765,17 @@ guestfs_impl_add_drive_opts (guestfs_h *g, const char *filename,
   }
   else
     data.discard = discard_disable;
+
+  if (optargs->bitmask & GUESTFS_ADD_DRIVE_OPTS_DEVICE_BITMASK) {
+    if (STREQ (optargs->device, "disk")) {
+        data.device = device_disk;
+    }
+    if (STREQ (optargs->device, "cdrom")) {
+        data.device = device_cdrom;
+    }
+  }
+  else
+      data.device = device_disk;
 
   data.copyonread =
     optargs->bitmask & GUESTFS_ADD_DRIVE_OPTS_COPYONREAD_BITMASK

--- a/lib/guestfs-internal.h
+++ b/lib/guestfs-internal.h
@@ -236,6 +236,11 @@ enum discard {
   discard_besteffort,
 };
 
+enum device {
+  device_disk = 0,
+  device_cdrom,
+};
+
 /**
  * There is one C<struct drive> per drive, including hot-plugged drives.
  */
@@ -261,6 +266,7 @@ struct drive {
   char *cachemode;
   enum discard discard;
   bool copyonread;
+  enum device device;
 };
 
 /* Extra hv parameters (from guestfs_config). */

--- a/lib/launch-direct.c
+++ b/lib/launch-direct.c
@@ -327,7 +327,10 @@ add_drive (guestfs_h *g, struct backend_direct_data *data,
       append_list ("if=none");
     } end_list ();
     start_list ("-device") {
-      append_list ("scsi-hd");
+      if (drv->device == device_cdrom)
+        append_list ("scsi-cd");
+      else
+        append_list ("scsi-hd");
       append_list_format ("drive=hd%zu", i);
     } end_list ();
   }
@@ -969,7 +972,8 @@ make_appliance_dev (guestfs_h *g)
 
   /* Calculate the index of the drive. */
   ITER_DRIVES (g, i, drv) {
-    if (drv->iface == NULL || STREQ (drv->iface, "ide"))
+    if ((drv->iface == NULL || STREQ (drv->iface, "ide"))
+            && drv->device == device_disk)
       index++;
   }
 


### PR DESCRIPTION
Added parsing device value in xml and implemented using "scsi-cd" except "scsi-hd" for qemu command in device=cdrom case.