### PR TITLE
Fix error with --uninstall option on SUSE

### DIFF
--- a/customize/customize_run.ml
+++ b/customize/customize_run.ml
@@ -181,7 +181,7 @@ exec >>%s 2>&1
     | "urpmi" ->  sprintf "urpme %s" quoted_args
     | "xbps" ->   sprintf "xbps-remove -Sy %s" quoted_args
     | "yum" ->    sprintf "yum -y remove %s" quoted_args
-    | "zypper" -> sprintf "zypper -n rm -l %s" quoted_args
+    | "zypper" -> sprintf "zypper -n rm %s" quoted_args
 
     | "unknown" ->
       error_unknown_package_manager (s_"--uninstall")


### PR DESCRIPTION
The `-l` option for some `zypper` subcommands is short for `--auto-agree-with-licenses` and not available on the `zypper rm` command.