### PR TITLE
erlang: Port to libei for Erlang 23

### DIFF
--- a/erlang/Makefile.am
+++ b/erlang/Makefile.am
@@ -90,7 +90,6 @@ erl_guestfs_CFLAGS = \
 	$(WARN_CFLAGS) $(WERROR_CFLAGS)
 
 erl_guestfs_LDADD = \
-	$(ERLANG_LIB_DIR_erl_interface)/lib/liberl_interface.a \
 	$(ERLANG_LIB_DIR_erl_interface)/lib/libei.a \
 	-lpthread \
 	$(top_builddir)/common/utils/libutils.la \


### PR DESCRIPTION
Replace the use of liberl_interface, which is removed in Erlang 23,
by libei. The implementation uses the ei_decode_iodata() function
which has been introduces only for Erlang 23, so it doesnt work with
earlier Erlang versions.