### PR TITLE
appliance: Add ntfs-3g-system-compression for Mageia

### DIFF
--- a/appliance/packagelist.in
+++ b/appliance/packagelist.in
@@ -173,6 +173,7 @@ ifelse(MAGEIA,1,
   nilfs-utils
   ntfsprogs
   ntfs-3g
+  ntfs-3g-system-compression
   openssh-clients
   reiserfs-utils
   systemd /* for /sbin/reboot and udevd */


### PR DESCRIPTION
This package in Mageia enables optional support for Windows 10
"CompactOS" (file-level compression), read-only, which is sufficient
for inspecting Windows guests and doing certain types of modifications
to them.  Virt-v2v appears to work, but it may be that anything that
involves modifying a compressed file might not work.

See commit e6764a5415b198a9e563473fd9b41077b9e71970