### PR TITLE
Use PKG_CHECK_MODULES instead of AC_CHECK_LIB for libmagic

### DIFF
--- a/m4/guestfs-libraries.m4
+++ b/m4/guestfs-libraries.m4
@@ -258,7 +258,7 @@ AC_CHECK_FUNCS([aug_source])
 LIBS="$old_LIBS"
 
 dnl libmagic (required)
-AC_CHECK_LIB([magic],[magic_file],[
+PKG_CHECK_MODULES([LIBMAGIC], [libmagic], [
     AC_CHECK_HEADER([magic.h],[
         AC_SUBST([MAGIC_LIBS], ["-lmagic"])
     ], [])


### PR DESCRIPTION
As requested in https://listman.redhat.com/archives/libguestfs/2021-May/msg00011.html.

With this change it is possible to get libmagic discovered from a non-standard prefix using e.g. `LIBMAGIC_LIBS="~/.local/lib64" LIBMAGIC_CFLAGS="-O3"` (there may also be a way using `PKG_CONFIG_PATH` that I'm not aware of).

Without this change discovery can be achieved with `LDFLAGS="-L ~/.local/lib64"`.

Note the `magic.h` header file also needs to be discoverable, which I achieved using `CPPFLAGS="-I ~/.local/include"`.