### PR TITLE
launch: board model for RISC-V

### DIFF
--- a/lib/guestfs-internal.h
+++ b/lib/guestfs-internal.h
@@ -157,6 +157,9 @@ cleanup_mutex_unlock (pthread_mutex_t **ptr)
 #ifdef __powerpc__
 #define MACHINE_TYPE "pseries"
 #endif
+#ifdef __riscv
+#define MACHINE_TYPE "virt"
+#endif
 
 /* Differences in qemu device names on ARMv7 (virtio-mmio), s/390x
  * (CCW) vs normal hardware with PCI.


### PR DESCRIPTION
On RISC-V there is no default machine type. Invoking QEMU requires to
specify a board model with the -M option. So let's define MACHINE_TYPE
as virt.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>