### PR TITLE
daemon: cryptsetup_open: Add --cipher

### DIFF
--- a/daemon/cryptsetup.ml
+++ b/daemon/cryptsetup.ml
@@ -23,7 +23,7 @@ open Std_utils
 
 open Utils
 
-let cryptsetup_open ?(readonly = false) ?crypttype device key mapname =
+let cryptsetup_open ?(readonly = false) ?crypttype ?cipher device key mapname =
   (* Sanity check: /dev/mapper/mapname must not exist already.  Note
    * that the device-mapper control device (/dev/mapper/control) is
    * always there, so you can't ever have mapname == "control".
@@ -53,6 +53,7 @@ let cryptsetup_open ?(readonly = false) ?crypttype device key mapname =
   List.push_back_list args ["-d"; keyfile];
   if readonly then List.push_back args "--readonly";
   List.push_back_list args ["open"; device; mapname; "--type"; crypttype];
+  Option.iter (fun s -> List.push_back_list args ["--cipher"; s]) cipher;
 
   (* Make sure we always remove the temporary file. *)
   protect ~f:(fun () -> ignore (command "cryptsetup" !args))

--- a/generator/actions_core.ml
+++ b/generator/actions_core.ml
@@ -9661,7 +9661,7 @@ This returns the UUID of the LUKS device C<device>." };
 
   { defaults with
     name = "cryptsetup_open"; added = (1, 43, 2);
-    style = RErr, [String (Device, "device"); String (Key, "key"); String (PlainString, "mapname")], [OBool "readonly"; OString "crypttype"];
+    style = RErr, [String (Device, "device"); String (Key, "key"); String (PlainString, "mapname")], [OBool "readonly"; OString "crypttype"; OString "cipher";];
     impl = OCaml "Cryptsetup.cryptsetup_open";
     optional = Some "luks";
     test_excuse = "no way to format BitLocker, and smallest device is huge";
@@ -9702,6 +9702,9 @@ A Windows BitLocker device.
 
 The optional C<readonly> flag, if set to true, creates a
 read-only mapping.
+
+The optional C<cipher> parameter allows specifying which
+cipher to use.
 
 If this block device contains LVM volume groups, then
 calling C<guestfs_lvm_scan> with the C<activate>


### PR DESCRIPTION
This allows passing the --cipher argument to cryptsetup as an optional parameter.