### PR TITLE
Fix dhcpcd failing on systemd-resolved stub

### DIFF
--- a/appliance/init
+++ b/appliance/init
@@ -115,6 +115,10 @@ if test "$guestfs_network" = 1; then
     # Two workarounds for Ubuntu:
     touch /etc/fstab
     rm -f /etc/dhcp/dhclient-enter-hooks.d/resolved
+    # Prevent dhcpcd from failing when /etc/resolv.conf is a dangling symlink.
+    if [ -L "/etc/resolv.conf" ] && [ ! -e "/etc/resolv.conf" ]; then
+        rm -f /etc/resolv.conf
+    fi
     if dhclient --version >/dev/null 2>&1; then
         dhclient $iface
     elif dhcpcd $iface; then


### PR DESCRIPTION
dhcpcd fails to update /etc/resolv.conf if is a dangling symlink, so remove it if it is.

This happens on Arch Linux when systemd-resolved is enabled by symlinking /etc/resolv.conf to /run/systemd/resolve/stub-resolv.conf. The symlink is copied into the supermin appliance, but the target file is not and this causes dhcpcd to fail when it tries to update /etc/resolv.conf.

The handling of /etc/resolv.conf could be improved in dhcpcd but it's not their job to decide when to remove the symlink. We do have the authority to decide whether or not to use systemd-resolved or resolvconf in the appliance, so we can remove it.