### PR TITLE
common: update submodule

### DIFF
--- a/generator/customize.ml
+++ b/generator/customize.ml
@@ -341,12 +341,6 @@ The path to the ISO image containing the virtio-win drivers
 The directory containing the unpacked virtio-win drivers
 (eg. F</usr/share/virtio-win>).
 
-=item B<\"osinfo\">
-
-The literal string C<\"osinfo\"> means to use the
-libosinfo database to locate the drivers.  (See
-L<osinfo-query(1)>.
-
 =back
 
 Note that to do a full conversion of a Windows guest from a


### PR DESCRIPTION
    Cole Robinson (2):
          mltools: decouple and simplify osinfo device support checks
          mlcustomize: disable `--inject-virtio-win osinfo`

    Richard W.M. Jones (3):
          mltools: Fix de-oUnit-ized tests
          mltools: Unreference various objects
          Revert "mltools: Unreference various objects"

And update customize docs to match