### PR TITLE
fuse: Ignore extra flags parameter on macOS

### DIFF
--- a/fuse/guestunmount.c
+++ b/fuse/guestunmount.c
@@ -32,6 +32,7 @@
 #include <libintl.h>
 #include <poll.h>
 #include <limits.h>
+#include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -753,7 +753,11 @@ mount_local_fsync (const char *path, int isdatasync,
 
 static int
 mount_local_setxattr (const char *path, const char *name, const char *value,
-		      size_t size, int flags)
+		      size_t size, int flags
+#ifdef __APPLE__
+                      , uint32_t extra_apple_options_ignored
+#endif
+                      )
 {
   int r;
   DECL_G ();
@@ -777,7 +781,11 @@ mount_local_setxattr (const char *path, const char *name, const char *value,
  */
 static int
 mount_local_getxattr (const char *path, const char *name, char *value,
-                      size_t size)
+                      size_t size
+#ifdef __APPLE__
+                      , uint32_t extra_apple_options_ignored
+#endif
+                      )
 {
   const struct guestfs_xattr_list *xattrs;
   int free_attrs = 0;


### PR DESCRIPTION
macOS macfuse has an extra parameter for the setxattr and getxattr FUSE callbacks.  It's unclear what this is for but we can ignore it.
```
Reported-by: Mohamed Akram
Fixes: https://github.com/libguestfs/libguestfs/issues/180
Related: https://github.com/macfuse/macfuse/issues/1065
```