### PR TITLE
bash: Replace 'cp -d' command with equivalent for macOS

### DIFF
--- a/bash/Makefile.am
+++ b/bash/Makefile.am
@@ -57,7 +57,7 @@ all-local: $(scripts) $(symlinks)
 
 install-data-local:
 	$(mkdir_p) $(DESTDIR)$(bashcompletiondir)
-	cp -d $(scripts) $(symlinks) $(DESTDIR)$(bashcompletiondir)
+	cp -P $(scripts) $(symlinks) $(DESTDIR)$(bashcompletiondir)
 
 clean-local:
 	-test $(srcdir) != $(builddir) && rm -f $(scripts)


### PR DESCRIPTION
```
Fixes: https://github.com/libguestfs/libguestfs/issues/183
Reported-by: Mohamed Akram
```

---

Untested as I have no working macOS machine to test this on.