### PR TITLE
inspection: Ignore btrfs snapshots of roots

### DIFF
--- a/daemon/inspect.ml
+++ b/daemon/inspect.ml
@@ -70,7 +70,7 @@ let rec inspect_os () =
   (* Save what we found in a global variable. *)
   Inspect_types.inspect_fses := fses;
 
-  (* At this point we have, in the handle, a list of all filesystems
+  (* At this point we have (in a global variable) a list of all filesystems
    * found and data about each one.  Now we assemble the list of
    * filesystems which are root devices.
    *


### PR DESCRIPTION
It's hard to come up with a good fix for this, since the existing behaviour is arguably correct.  The guest really is multi-boot!  However it's not useful to display all these snapshots, and it causes real problems when converting SUSE guests.  I tried to keep the test very narrow, so it should only affect SUSE guests and nothing else (Fedora doesn't seem affected by this problem, if it's a problem).

Commit message from the main commit follows below.

---

In SLES guests in particular, btrfs snapshots seem to be used to allow rollback of changes made to the filesystem.  Dozens of snapshots may be present.  Technically therefore these are multi-boot guests.  The libguestfs concept of "root" of an operating system does not map well to this, causing problems in virt-inspector and virt-v2v.

In this commit we ignore these duplicates.  The test is quite narrow to avoid false positives: We only remove a duplicate if it is a member of a parent device, both are btrfs, both the snapshot and parent have a root role, and the roles are otherwise very similar.

There may be a case for reporting this information separately in future, although it's also easy to find this out now.  For example, when you see a btrfs root device returned by inspect_os, you could call btrfs_subvolume_list on the root device to list the snapshots.

Fixes: https://issues.redhat.com/browse/RHEL-93109

@crobinso 