### PR TITLE
daemon/inspect_fs_windows.ml: Ignore blank disks in drive mapping

### DIFF
--- a/daemon/inspect_fs_windows.ml
+++ b/daemon/inspect_fs_windows.ml
@@ -376,6 +376,10 @@ and map_registry_disk_blob_mbr devices blob =
      * disk with this disk ID.
      *)
     let diskid = String.sub blob 0 4 in
+    if verbose () then
+      eprintf "map_registry_disk_blob_mbr: searching for MBR disk ID %s\n%!"
+        (hex_of_string diskid);
+
     let device =
       List.find (
         fun dev ->
@@ -388,6 +392,10 @@ and map_registry_disk_blob_mbr devices blob =
      * partition byte offset from Parted.part_list.
      *)
     let offset = String.sub blob 4 8 in
+    if verbose () then
+      eprintf "map_registry_disk_blob_mbr: searching for MBR partition offset \
+               %s\n%!"
+        (hex_of_string offset);
     let offset = int_of_le64 offset in
     let partitions = Parted.part_list device in
     let partition =

--- a/daemon/inspect_fs_windows.ml
+++ b/daemon/inspect_fs_windows.ml
@@ -207,6 +207,12 @@ and check_windows_registry systemroot data =
     if Is.is_file system_hive then Some system_hive else None in
   data.windows_system_hive <- system_hive;
 
+  if verbose () then
+    eprintf "check_windows_registry: software hive: %s\n\
+             check_windows_registry: system hive: %s\n%!"
+      (Option.value ~default:"None" software_hive)
+      (Option.value ~default:"None" system_hive);
+
   match software_hive, system_hive with
   | None, _ | Some _, None -> ()
   | Some software_hive, Some system_hive ->

--- a/daemon/utils.ml
+++ b/daemon/utils.ml
@@ -291,3 +291,7 @@ let parse_key_value_strings ?unquote lines =
   match unquote with
   | None -> lines
   | Some f -> List.map (fun (k, v) -> (k, f v)) lines
+
+let hex_of_string s =
+  let bytes = String.map_chars (fun c -> sprintf "%02x" (Char.code c)) s in
+  String.concat " " bytes

--- a/daemon/utils.mli
+++ b/daemon/utils.mli
@@ -121,5 +121,9 @@ val parse_key_value_strings : ?unquote:(string -> string) -> string list -> (str
     it is applied on the values as unquote function.  Empty lines,
     or that start with a comment character [#], are ignored. *)
 
+val hex_of_string : string -> string
+(** Return a string as a list of hex bytes.
+    Use this for debugging msgs only. *)
+
 (**/**)
 val get_verbose_flag : unit -> bool


### PR DESCRIPTION
@crobinso 

If `HKLM\System\MountedDevices` references a blank disk, then when we try to search for the actual backing device we will get an error from parted:

```
parted: /dev/sdb: parted exited with status 1: Error: /dev/sdb: unrecognised disk label: Invalid argument
```    
Just ignore these errors instead of failing inspection.

Fixes: https://issues.redhat.com/browse/RHEL-108803
