### PR TITLE
WIP: run qemu:///system VMs as root.root

### DIFF
--- a/lib/launch-libvirt.c
+++ b/lib/launch-libvirt.c
@@ -1262,7 +1262,7 @@ construct_libvirt_xml_seclabel (guestfs_h *g,
       attribute ("type", "none");
     } end_element ();
   }
-  else if (params->data->selinux_label && params->data->selinux_imagelabel) {
+  else if (params->data->selinux_label) {
     /* Enable sVirt and pass a custom <seclabel/> inherited from the
      * original libvirt domain (when guestfs_add_domain was called).
      * https://bugzilla.redhat.com/show_bug.cgi?id=912499#c7
@@ -1272,7 +1272,6 @@ construct_libvirt_xml_seclabel (guestfs_h *g,
       attribute ("model", "selinux");
       attribute ("relabel", "yes");
       single_element ("label", params->data->selinux_label);
-      single_element ("imagelabel", params->data->selinux_imagelabel);
     } end_element ();
   }
 

--- a/lib/launch-libvirt.c
+++ b/lib/launch-libvirt.c
@@ -1238,6 +1238,7 @@ construct_libvirt_xml_seclabel (guestfs_h *g,
     /* This disables SELinux/sVirt confinement. */
     start_element ("seclabel") {
       attribute ("type", "none");
+      attribute ("model", "selinux");
     } end_element ();
   }
   else if (params->data->selinux_label) {

--- a/lib/launch-libvirt.c
+++ b/lib/launch-libvirt.c
@@ -1254,6 +1254,19 @@ construct_libvirt_xml_seclabel (guestfs_h *g,
     } end_element ();
   }
 
+  /* if we are root, that means we connected to qemu:///system, and libvirt
+   * is likely running VMs as qemu.qemu. instead tell it to relabel
+   * everything as root.root, which is closer to what we want
+   */
+  if (params->current_proc_is_root) {
+    start_element ("seclabel") {
+      attribute ("type", "static");
+      attribute ("model", "dac");
+      attribute ("relabel", "yes");
+      single_element ("label", "+0:+0");
+    } end_element ();
+  }
+
   return 0;
 }
 

--- a/lib/launch-libvirt.c
+++ b/lib/launch-libvirt.c
@@ -25,7 +25,6 @@
 #include <unistd.h>
 #include <limits.h>
 #include <fcntl.h>
-#include <grp.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -527,51 +526,30 @@ launch_libvirt (guestfs_h *g, void *datav, const char *libvirt_uri)
 
   clear_socket_create_context (g);
 
-  /* libvirt, if running as root, will run the qemu process as
-   * qemu.qemu, which means it won't be able to access the socket.
-   * There are roughly three things that get in the way:
+
+  /* Ff we are running as root, libvirt via qemu:///system is likely running
+   * VMs as qemu.qemu, which means qemu may not be able to access the sockets
+   * we just created.
    *
-   * (1) Permissions of the socket.
+   * libvirt DAC and selinux relabeling will take care of most issues,
+   * but the whole directory hierarchy needs +x permissions for the qemu
+   * user (remember this if you have a funky $TMPDIR)
    *
-   * (2) Permissions of the parent directory(-ies).  Remember this if
-   *     $TMPDIR is located in your home directory.
-   *
-   * (3) SELinux/sVirt will prevent access.  libvirt ought to label
-   *     the socket.
-   *
-   * Note that the 'current_proc_is_root' flag here just means that we
-   * are root.  It's also possible for non-root user to try to use the
+   * It's also possible for non-root user to try to use the
    * system libvirtd by specifying a qemu:///system URI (RHBZ#913774)
    * but there's no sane way to test for that.
+   *
+   * These chmod calls are actually about socket access
    */
-  if (params.current_proc_is_root) {
-    /* Current process is root, so try to create sockets that are
-     * owned by root.qemu with mode 0660 and hence accessible to qemu.
-     */
-    struct group *grp;
 
-    if (chmod (data->guestfsd_path, 0660) == -1) {
-      perrorf (g, "chmod: %s", data->guestfsd_path);
-      goto cleanup;
-    }
+  if (chmod (data->guestfsd_path, 0660) == -1) {
+    perrorf (g, "chmod: %s", data->guestfsd_path);
+    goto cleanup;
+  }
 
-    if (chmod (data->console_path, 0660) == -1) {
-      perrorf (g, "chmod: %s", data->console_path);
-      goto cleanup;
-    }
-
-    grp = getgrnam ("qemu");
-    if (grp != NULL) {
-      if (chown (data->guestfsd_path, 0, grp->gr_gid) == -1) {
-        perrorf (g, "chown: %s", data->guestfsd_path);
-        goto cleanup;
-      }
-      if (chown (data->console_path, 0, grp->gr_gid) == -1) {
-        perrorf (g, "chown: %s", data->console_path);
-        goto cleanup;
-      }
-    } else
-      debug (g, "cannot find group 'qemu'");
+  if (chmod (data->console_path, 0660) == -1) {
+    perrorf (g, "chmod: %s", data->console_path);
+    goto cleanup;
   }
 
   /* Store any secrets in libvirtd, keeping a mapping from the secret


### PR DESCRIPTION
Some cleanups, and then the `<seclabel>` bits to make it work.

This is mostly working, tests all pass except this, which I haven't dug into yet:

```
sudo ./run guestfish --network -i -d win10
libguestfs: error: could not create appliance through libvirt. Original error from libvirt: internal error: Child process (passt --one-off --socket /run/libvirt/qemu/passt/15-guestfs-ov3ds4sv9063-net0.socket --pid /run/libvirt/qemu/passt/15-guestfs-ov3ds4sv9063-net0-passt.pid --address 169.254.2.15 --netmask 16) unexpected exit status 1: Started as root, will change to nobody.
Failed to bind UNIX domain socket: Permission denied
 [code=1 int1=-1]
```