### PR TITLE
tests: increase mount retries for test-parallel-mount-local

### DIFF
--- a/tests/mount-local/test-parallel-mount-local.c
+++ b/tests/mount-local/test-parallel-mount-local.c
@@ -371,7 +371,7 @@ guestunmount (const char *mp, unsigned flags)
   }
 
   snprintf (cmd, sizeof cmd,
-            "../fuse/guestunmount%s %s",
+            "../fuse/guestunmount%s --retry 10 %s",
             (flags & GUESTUNMOUNT_SILENT) ? " --quiet" : "", mp);
 
   status = system (cmd);


### PR DESCRIPTION
test-parallel-mount-local reliably fails when my machines are under load (like running the test suite in parallel). The issue is /usr/libexec/gvfs-udisks2-volume-monitor fiddling with the fuse mounts, preventing them from being unmounted.

./fuse/guestunmount defaults to 5 unmount retries with increasing time backoff, but apparently that isn't enough. Bumping it to use 10 retries makes things more reliable for me.