### PR TITLE
gobject: skip test run-tests-retvalues

### DIFF
--- a/gobject/run-tests-retvalues
+++ b/gobject/run-tests-retvalues
@@ -23,4 +23,6 @@ set -x
 skip_if_skipped
 skip_unless_environment_variable_set GJS
 
+skip_because "deprecated and currently broken"
+
 $GJS $srcdir/bindtests-retvalues.js


### PR DESCRIPTION
This is currently broken, and gobject bits are slated to be removed entirely, so just disable this test.