### PR TITLE
daemon: lvm_utils: Handle stat errors

### DIFF
--- a/daemon/lvm_utils.ml
+++ b/daemon/lvm_utils.ml
@@ -47,7 +47,7 @@ let lv_canonical device =
           fun lv ->
             let stat2 =
               try Some (stat lv)
-              with Unix_error _ -> None in
+              with Unix_error (ENOENT, _, _) -> None in
             match stat2 with
             | Some stat2 -> stat1.st_rdev = stat2.st_rdev
             | None -> false


### PR DESCRIPTION
lvm returns logical volumes even if they're broken, for instance when a physical volume is missing in their volume group.
In such cases, stat would fail to resolve the provided path. Handle such cases by skipping such failures when finding the matching lvm device.