### PR TITLE
tests: python: drop skipUnlessLibvirtHasCPointer

### DIFF
--- a/python/t/test820RHBZ912499.py
+++ b/python/t/test820RHBZ912499.py
@@ -32,7 +32,6 @@ from .tests_helper import *
 @skipIfEnvironmentVariableSet("SKIP_TEST820RHBZ912499_PY")
 @skipUnlessArchMatches("(i.86|x86_64)")
 @skipUnlessGuestfsBackendIs('libvirt')
-@skipUnlessLibvirtHasCPointer()
 class Test820RHBZ912499(unittest.TestCase):
     def setUp(self):
         # Create a test disk.

--- a/python/t/test910Libvirt.py
+++ b/python/t/test910Libvirt.py
@@ -29,7 +29,6 @@ guestsdir = os.environ['guestsdir']
 
 
 @skipUnlessConfiguredWithLibvirt()
-@skipUnlessLibvirtHasCPointer()
 class Test910Libvirt(unittest.TestCase):
     def test_libvirt(self):
         import libvirt

--- a/python/t/tests_helper.py.in
+++ b/python/t/tests_helper.py.in
@@ -48,23 +48,6 @@ def skipUnlessConfiguredWithLibvirt():
     return lambda func: func
 
 
-def skipUnlessLibvirtHasCPointer():
-    """
-    Skip the current class/method if:
-      (a) libvirt cannot be imported (e.g. not installed)
-      (b) connection objects don't have the c_pointer() method (too old)
-    """
-    try:
-        import libvirt
-    except ImportError:
-        return unittest.skip("could not import libvirt")
-    # Check we're using the version of libvirt-python that has
-    # c_pointer() methods.
-    if "c_pointer" not in dir(libvirt.open(None)):
-        return unittest.skip("libvirt-python doesn't support c_pointer()")
-    return lambda func: func
-
-
 def skipUnlessGuestfsBackendIs(wanted):
     """
     Skip the current class/method if the default backend of libguestfs


### PR DESCRIPTION
This was added in 2014, we can safely depend on it being available now. Existing tests will ensure it doesn't regress


libvirt.open(None) was failing for me in some ci testing[1]. not sure why, and that will probably cause a later python test to fail, but this code can go away in the meantime

[1] libvirt.libvirtError: Operation not supported: No URI is provided and cannot identify any listening daemon socket path to attempt to connect to. Please ensure the expected daemon sockets are active and/or provide an explicit URI. For more information see https://libvirt.org/kbase/failed_connection_after_install.html
