### PR TITLE
WIP: fix `list-filesystems` for `sun` layout images

### DIFF
--- a/daemon/parted.ml
+++ b/daemon/parted.ml
@@ -25,43 +25,64 @@ open Utils
 
 include Structs
 
+(* External C function to get partition table for sun disks using sfdisk --json.
+ * Returns formatted output matching parted's machine-readable format.
+ *)
+external sfdisk_sun_partition_table : string -> string =
+  "guestfs_int_daemon_sfdisk_sun_partition_table"
+
 (* This is almost equivalent to print_partition_table in the C code. The
  * difference is that here we enforce the "BYT;" header internally.
  *)
 let print_partition_table_machine_readable device =
-  udev_settle ();
-
-  let args = ref [] in
-  List.push_back args "-m";
-  List.push_back args "-s";
-  List.push_back args "--";
-  List.push_back args device;
-  List.push_back args "unit";
-  List.push_back args "b";
-  List.push_back args "print";
-
-  let out =
-    try command "parted" !args
-    with
-      (* Translate "unrecognised disk label" into an errno code. *)
-      Failure str when String.find str "unrecognised disk label" >= 0 ->
-        raise (Unix.Unix_error (Unix.EINVAL, "parted", device ^ ": " ^ str)) in
-
-  udev_settle ();
-
-  (* Split the output into lines. *)
-  let out = String.trim out in
-  let lines = String.nsplit "\n" out in
-
-  (* lines[0] is "BYT;", lines[1] is the device line,
-   * lines[2..] are the partitions themselves.
+  (* Check if this is a sun disk - parted doesn't handle these well.
+   * Sun disk labels have a magic number 0xDABE at offset 508.
    *)
-  match lines with
-  | "BYT;" :: device_line :: lines -> device_line, lines
-  | [] | [_] ->
-     failwith "too few rows of output from 'parted print' command"
-  | _ ->
-     failwith "did not see 'BYT;' magic value in 'parted print' command"
+  if Utils.is_sun_disk device then (
+    (* Use sfdisk for sun disks since parted has geometry issues with them.
+     * The C function returns formatted output matching parted's format.
+     *)
+    let formatted_output = sfdisk_sun_partition_table device in
+    let lines = String.nsplit "\n" (String.trim formatted_output) in
+    match lines with
+    | device_line :: partition_lines -> device_line, partition_lines
+    | _ -> failwith "sfdisk_sun_partition_table: unexpected output format"
+  )
+  else (
+    udev_settle ();
+
+    let args = ref [] in
+    List.push_back args "-m";
+    List.push_back args "-s";
+    List.push_back args "--";
+    List.push_back args device;
+    List.push_back args "unit";
+    List.push_back args "b";
+    List.push_back args "print";
+
+    let out =
+      try command "parted" !args
+      with
+        (* Translate "unrecognised disk label" into an errno code. *)
+        Failure str when String.find str "unrecognised disk label" >= 0 ->
+          raise (Unix.Unix_error (Unix.EINVAL, "parted", device ^ ": " ^ str)) in
+
+    udev_settle ();
+
+    (* Split the output into lines. *)
+    let out = String.trim out in
+    let lines = String.nsplit "\n" out in
+
+    (* lines[0] is "BYT;", lines[1] is the device line,
+     * lines[2..] are the partitions themselves.
+     *)
+    match lines with
+    | "BYT;" :: device_line :: lines -> device_line, lines
+    | [] | [_] ->
+       failwith "too few rows of output from 'parted print' command"
+    | _ ->
+       failwith "did not see 'BYT;' magic value in 'parted print' command"
+  )
 
 let part_list device =
   let _, lines = print_partition_table_machine_readable device in

--- a/daemon/sfdisk.c
+++ b/daemon/sfdisk.c
@@ -24,6 +24,15 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <ctype.h>
+#include <inttypes.h>
+
+#include <json.h>
+
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
 
 #include "daemon.h"
 #include "actions.h"
@@ -164,4 +173,169 @@ char *
 do_sfdisk_disk_geometry (const char *device)
 {
   return sfdisk_flag (device, "-G");
+}
+
+/* Get partition table for sun disks using sfdisk --json.
+ * Returns a formatted string compatible with parted's machine-readable output.
+ * Format: "device_line\npartition_line1\npartition_line2\n..."
+ * where device_line is: "/dev/sda:SIZEB:TYPE:SECTORSIZE:SECTORSIZE:LABEL:;"
+ * and partition_line is: "NUM:STARTB:ENDB:SIZEB:::"
+ */
+char *
+do_sfdisk_sun_partition_table (const char *device)
+{
+  CLEANUP_FREE char *out = NULL, *err = NULL;
+  char *result = NULL;  /* caller frees */
+  int r;
+  json_object *root = NULL, *pt = NULL, *partitions = NULL;
+  json_object *tmp = NULL;
+  const char *label = NULL;
+  int64_t sectorsize = 512;
+  int64_t device_size = 0;
+  struct stat statbuf;
+  size_t result_size = 0, result_alloc = 4096;
+
+  /* Get device size using stat */
+  if (stat (device, &statbuf) == 0 && S_ISREG (statbuf.st_mode))
+    device_size = statbuf.st_size;
+
+  /* Run sfdisk --json */
+  r = command (&out, &err, "sfdisk", "--json", device, NULL);
+  if (r == -1) {
+    reply_with_error ("sfdisk --json %s: %s", device, err);
+    return NULL;
+  }
+
+  /* Parse JSON output */
+  root = json_tokener_parse (out);
+  if (root == NULL) {
+    reply_with_error ("sfdisk --json: failed to parse JSON output");
+    return NULL;
+  }
+
+  /* Get partitiontable object */
+  if (!json_object_object_get_ex (root, "partitiontable", &pt)) {
+    reply_with_error ("sfdisk --json: missing 'partitiontable' in output");
+    json_object_put (root);
+    return NULL;
+  }
+
+  /* Get label type */
+  if (json_object_object_get_ex (pt, "label", &tmp))
+    label = json_object_get_string (tmp);
+  if (label == NULL)
+    label = "unknown";
+
+  /* Get sector size */
+  if (json_object_object_get_ex (pt, "sectorsize", &tmp))
+    sectorsize = json_object_get_int64 (tmp);
+
+  /* Allocate result buffer */
+  result = malloc (result_alloc);
+  if (result == NULL) {
+    reply_with_perror ("malloc");
+    json_object_put (root);
+    return NULL;
+  }
+
+  /* Format device line: /dev/sda:104857600B:file:512:512:sun:; */
+  r = snprintf (result, result_alloc, "%s:%"PRId64"B:file:%"PRId64":%"PRId64":%s:;",
+                device, device_size, sectorsize, sectorsize, label);
+  if (r < 0 || (size_t) r >= result_alloc) {
+    reply_with_error ("snprintf: device line too long");
+    free (result);
+    json_object_put (root);
+    return NULL;
+  }
+  result_size = r;
+
+  /* Get partitions array */
+  if (!json_object_object_get_ex (pt, "partitions", &partitions)) {
+    /* No partitions is OK, just return device line */
+    json_object_put (root);
+    return result;
+  }
+
+  /* Process each partition */
+  size_t n_partitions = json_object_array_length (partitions);
+  for (size_t i = 0; i < n_partitions; i++) {
+    json_object *part = json_object_array_get_idx (partitions, i);
+    const char *node = NULL;
+    int64_t start = 0, size = 0;
+    int partnum = 0;
+
+    /* Get partition node name to extract number */
+    if (json_object_object_get_ex (part, "node", &tmp))
+      node = json_object_get_string (tmp);
+
+    /* Extract partition number from node name (e.g., "sun.img1" -> 1) */
+    if (node) {
+      const char *p = node + strlen (node);
+      while (p > node && isdigit (*(p-1)))
+        p--;
+      if (*p)
+        partnum = atoi (p);
+    }
+
+    /* Get start sector */
+    if (json_object_object_get_ex (part, "start", &tmp))
+      start = json_object_get_int64 (tmp);
+
+    /* Get size in sectors */
+    if (json_object_object_get_ex (part, "size", &tmp))
+      size = json_object_get_int64 (tmp);
+
+    /* Convert sectors to bytes */
+    int64_t start_bytes = start * sectorsize;
+    int64_t size_bytes = size * sectorsize;
+    int64_t end_bytes = start_bytes + size_bytes - 1;
+
+    /* Ensure we have enough space in buffer */
+    if (result_size + 200 > result_alloc) {
+      result_alloc *= 2;
+      char *new_result = realloc (result, result_alloc);
+      if (new_result == NULL) {
+        reply_with_perror ("realloc");
+        free (result);
+        json_object_put (root);
+        return NULL;
+      }
+      result = new_result;
+    }
+
+    /* Format partition line: 1:0B:65802239B:65802240B::: */
+    r = snprintf (result + result_size, result_alloc - result_size,
+                  "\n%d:%"PRId64"B:%"PRId64"B:%"PRId64"B:::",
+                  partnum, start_bytes, end_bytes, size_bytes);
+    if (r < 0 || result_size + (size_t) r >= result_alloc) {
+      reply_with_error ("snprintf: partition line too long");
+      free (result);
+      json_object_put (root);
+      return NULL;
+    }
+    result_size += r;
+  }
+
+  json_object_put (root);
+  return result;
+}
+
+/* OCaml binding for sun_partition_table.
+ * Called from Sfdisk.sun_partition_table in OCaml code.
+ */
+value
+guestfs_int_daemon_sfdisk_sun_partition_table (value devicev)
+{
+  CAMLparam1 (devicev);
+  CAMLlocal1 (rv);
+  const char *device = String_val (devicev);
+  char *result;
+
+  result = do_sfdisk_sun_partition_table (device);
+  if (result == NULL)
+    caml_failwith ("sfdisk_sun_partition_table failed");
+
+  rv = caml_copy_string (result);
+  free (result);
+  CAMLreturn (rv);
 }

--- a/daemon/utils.ml
+++ b/daemon/utils.ml
@@ -233,6 +233,23 @@ let has_bogus_mbr device =
     )
   with _ -> false
 
+let is_sun_disk device =
+  try
+    with_openfile device [O_RDONLY; O_CLOEXEC] 0 (fun fd ->
+      let sec0size = 0x200
+      and magic_ofs = 0x1FC in (* offset 508, magic is at bytes 508-509 *)
+      let sec0 = Bytes.create sec0size in
+      let sec0read = read fd sec0 0 sec0size in
+
+      (* sector read completely *)
+      sec0read = sec0size &&
+
+      (* Sun disk label magic number 0xDABE at offset 508 (big-endian) *)
+      Bytes.get_uint8 sec0 magic_ofs = 0xDA &&
+      Bytes.get_uint8 sec0 (magic_ofs + 1) = 0xBE
+    )
+  with _ -> false
+
 let proc_unmangle_path path =
   let n = String.length path in
   let b = Buffer.create n in

--- a/daemon/utils.mli
+++ b/daemon/utils.mli
@@ -69,6 +69,13 @@ val has_bogus_mbr : string -> bool
     formatting non-removable, non-partitioned block devices. Refer to
     RHBZ#1931821. *)
 
+val is_sun_disk : string -> bool
+(** Check whether the device has a Sun disk label by reading the magic number
+    at offset 508. The Sun disk label magic is 0xDABE (big-endian).
+
+    Sun disk labels are not handled well by parted due to geometry validation
+    issues, so this function helps detect them for special handling. *)
+
 val proc_unmangle_path : string -> string
 (** Reverse kernel path escaping done in fs/seq_file.c:mangle_path.
     This is inconsistently used for /proc fields. *)


### PR DESCRIPTION
code is claude generated, I have not looked over it closely. I'm floating this now to get feedback on the general approach.

known issues:
  + sun partitions don't report fs type in list-filesystems. sfdisk doesn't report this info so we probably need to call an additional tool.

Reproducer:

```
  qemu-img create sun.img 100M
  fdisk sun.img
  > s
  > w
  ./run guestfish -a sun.img launch : list-filesystems
libguestfs: error: list_filesystems: parted exited with status 1: Warning: The disk CHS geometry (401,255,2) reported by the operating system does not match the geometry stored on the disk label (12,255,63).
```

`sun` disk formats are weird, including allowing overlapping partitions. `parted` is stricter than the kernel about interpreting them and our inspection calls fail. `parted` has some support for giving us the info we want, but only in interactive mode (call `print` and then select Ignore, but it also does not print overlapping partitions).

This changes things to detect the `sun` format up front and call `sfdisk` for partition inspection instead, which handles this case better.

The upfront check is done by reading for `sun` magic directly from the disk rather than call out to another command. My thought is this is quickest and lowest risk of interfering with non-sun disk use cases. But we could replace this with an sfdisk call.

I verified the reproducer is fixed, and virt-v2v works on a fedora libvirt VM with sun.img attached.