### PR TITLE
daemon: Set last_errno to EINVAL for OCaml Invalid_argument exns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -408,6 +408,7 @@ Makefile.in
 /tests/c-api/test-just-header
 /tests/c-api/test-just-header-cxx
 /tests/c-api/test-last-errno
+/tests/c-api/test-last-errno-einval
 /tests/c-api/test-private-data
 /tests/c-api/test-pwd
 /tests/c-api/tests

--- a/daemon/daemon-c.c
+++ b/daemon/daemon-c.c
@@ -64,7 +64,9 @@ guestfs_int_daemon_exn_to_reply_with_error (const char *func, value exn)
   else if (STREQ (exn_name, "Sys_error"))
     reply_with_error ("%s", String_val (Field (exn, 1)));
   else if (STREQ (exn_name, "Invalid_argument"))
-    reply_with_error ("invalid argument: %s", String_val (Field (exn, 1)));
+    reply_with_error_errno (EINVAL,
+                            "invalid argument: %s",
+                            String_val (Field (exn, 1)));
   else if (STREQ (exn_name, "Augeas.Error")) {
     const char *message = String_val (Field (exn, 3));
     const char *minor = String_val (Field (exn, 4));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,7 @@ check_PROGRAMS += \
 	c-api/test-config \
 	c-api/test-add-drive-opts \
 	c-api/test-last-errno \
+	c-api/test-last-errno-einval \
 	c-api/test-backend-settings \
 	c-api/test-private-data \
 	c-api/test-user-cancel \
@@ -91,6 +92,7 @@ TESTS += \
 	c-api/test-config \
 	c-api/test-add-drive-opts \
 	c-api/test-last-errno \
+	c-api/test-last-errno-einval \
 	c-api/test-backend-settings \
 	c-api/test-private-data \
 	c-api/test-user-cancel \
@@ -201,6 +203,13 @@ c_api_test_last_errno_CPPFLAGS = -I$(top_srcdir)/include
 c_api_test_last_errno_CFLAGS = \
 	$(WARN_CFLAGS) $(WERROR_CFLAGS)
 c_api_test_last_errno_LDADD = \
+	$(top_builddir)/lib/libguestfs.la
+
+c_api_test_last_errno_einval_SOURCES = c-api/test-last-errno-einval.c
+c_api_test_last_errno_einval_CPPFLAGS = -I$(top_srcdir)/include
+c_api_test_last_errno_einval_CFLAGS = \
+	$(WARN_CFLAGS) $(WERROR_CFLAGS)
+c_api_test_last_errno_einval_LDADD = \
 	$(top_builddir)/lib/libguestfs.la
 
 c_api_test_backend_settings_SOURCES = c-api/test-backend-settings.c

--- a/tests/c-api/test-last-errno-einval.c
+++ b/tests/c-api/test-last-errno-einval.c
@@ -1,0 +1,90 @@
+/* libguestfs
+ * Copyright (C) 2010-2026 Red Hat Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/* Test that OCaml Invalid_argument exceptions return EINVAL. */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <error.h>
+
+#include "guestfs.h"
+
+int
+main (int argc, char *argv[])
+{
+  guestfs_h *g;
+  int r, err;
+  const char *feature[] = { "xfs", NULL };
+
+  g = guestfs_create ();
+  if (g == NULL)
+    error (EXIT_FAILURE, errno, "guestfs_create");
+
+  guestfs_set_verbose (g, 1);
+  guestfs_set_trace (g, 1);
+
+  if (guestfs_add_drive_scratch (g, 524288000, -1) == -1)
+    exit (EXIT_FAILURE);
+
+  if (guestfs_launch (g) == -1)
+    exit (EXIT_FAILURE);
+
+  if (!guestfs_feature_available (g, (char **) feature)) {
+    printf ("skipping test because xfs is not available\n");
+    guestfs_close (g);
+    exit (77);
+  }
+
+  if (guestfs_mkfs (g, "xfs", "/dev/sda") == -1)
+    exit (EXIT_FAILURE);
+
+  /* Run xfs_repair with some bogus parameters.  We expect that it
+   * will fail with EINVAL.
+   */
+  r = guestfs_xfs_repair (g, "/dev/sda",
+                          GUESTFS_XFS_REPAIR_MAXMEM, UINT64_C(-100),
+                          -1);
+  if (r != -1)
+    error (EXIT_FAILURE, 0,
+           "guestfs_xfs_repair: expected failure because of bogus %s",
+           "maxmem");
+  err = guestfs_last_errno (g);
+  if (err != EINVAL)
+    error (EXIT_FAILURE, 0,
+           "guestfs_xfs_repair: expected errno == EINVAL, but got %d", err);
+
+  r = guestfs_xfs_repair (g, "/dev/sda",
+                          GUESTFS_XFS_REPAIR_BHASHSIZE, UINT64_C(-1),
+                          -1);
+  if (r != -1)
+    error (EXIT_FAILURE, 0,
+           "guestfs_xfs_repair: expected failure because of bogus %s",
+           "bhashsize");
+  err = guestfs_last_errno (g);
+  if (err != EINVAL)
+    error (EXIT_FAILURE, 0,
+           "guestfs_xfs_repair: expected errno == EINVAL, but got %d", err);
+
+  guestfs_close (g);
+
+  exit (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Currently if a function in the daemon raises an `Invalid_argument` exception (or calls `invalid_arg`, which is the same thing), we don't set any errno value.  Calling `guestfs_last_errno` from the client side will return 0.  We might as well return `EINVAL` for this.  This is simply extra information to help clients to distinguish these errors.