### PR TITLE
Fix libguestfs-test-tool

### DIFF
--- a/lib/handle.c
+++ b/lib/handle.c
@@ -560,14 +560,21 @@ guestfs_impl_get_hv (guestfs_h *g)
     /* Try to return the default hypervisor. */
     const char *default_hv;
 
-    if (g->backend_ops && g->backend_data &&
-        (default_hv = g->backend_ops->get_default_hv (g, g->backend_data))
-        != NULL)
-      return safe_strdup (g, default_hv);
-    else {
-      error (g, _("cannot get default hypervisor"));
+    if (!g->backend_ops || !g->backend_data) {
+      error (g, _("get_hv: cannot get default hypervisor "
+                  "before ‘launch’ is called"));
       return NULL;
     }
+
+    default_hv = g->backend_ops->get_default_hv (g, g->backend_data);
+    if (!default_hv) {
+      error (g, _("get_hv: cannot get default hypervisor: "
+                  "the ‘%s’ backend returned no value"),
+             g->backend);
+      return NULL;
+    }
+
+    return safe_strdup (g, default_hv);
   }
 }
 

--- a/test-tool/test-tool.c
+++ b/test-tool/test-tool.c
@@ -231,9 +231,6 @@ main (int argc, char *argv[])
   p = guestfs_get_cachedir (g);
   printf ("guestfs_get_cachedir: %s\n", p ? : "(null)");
   free (p);
-  p = guestfs_get_hv (g);
-  printf ("guestfs_get_hv: %s\n", p);
-  free (p);
   printf ("guestfs_get_memsize: %d\n", guestfs_get_memsize (g));
   printf ("guestfs_get_network: %d\n", guestfs_get_network (g));
   printf ("guestfs_get_path: %s\n", guestfs_get_path (g) ? : "(null)");
@@ -265,6 +262,11 @@ main (int argc, char *argv[])
 
   printf ("Guest launched OK.\n");
   fflush (stdout);
+
+  /* More debugging, after launch. */
+  p = guestfs_get_hv (g);
+  printf ("guestfs_get_hv: %s\n", p);
+  free (p);
 
   /* Create the filesystem and mount everything. */
   if (guestfs_part_disk (g, "/dev/sda", "mbr") == -1)


### PR DESCRIPTION
In RHEL regression testing, libguestfs-test-tool is failing with the very opaque error:
```
cannot get default hypervisor
```
Fix it.