### PR TITLE
daemon/xfs.ml: xfs_repair: Ignore RHEL 7 AGFL inconsistency

### DIFF
--- a/daemon/xfs.ml
+++ b/daemon/xfs.ml
@@ -176,6 +176,9 @@ let maxmem_re =
   PCRE.compile ~anchored:false ~dotall:true
     {|Required memory for repair is greater tha. the maximum specified.*at least (\d+)\.|}
 
+let bad_agbno_in_agfl_re =
+  PCRE.compile ~anchored:false {|bad agbno \d+ in agfl, agno \d+|}
+
 let xfs_repair
       ?(forcelogzero = false)
       ?(nomodify = false)
@@ -246,5 +249,19 @@ let xfs_repair
     let msg = sprintf "maxmem parameter (-m option) was too small: raise it from %s to at least %s" old_maxmem new_maxmem in
     invalid_arg msg
   );
+
+  (* RHEL 7 XFS had a bug in on-disk AGFL (free list) structs.  This
+   * was fixed later (linux kernel commit 96f859d).  But the RHEL 7
+   * kernel was patched to detect this case and do a fix up.  Later
+   * xfs_repair (eg RHEL 10) flags the RHEL 7 structs as an error,
+   * incorrectly.  Detect this case and ignore the error. (RHEL-178287)
+   *)
+  let r =
+    if r = 1 && PCRE.matches bad_agbno_in_agfl_re err then (
+      eprintf "xfs_repair: \
+               ignoring RHEL 7 AGFL inconsistency (RHEL-178287)\n%!";
+      0
+    )
+    else r in
 
   r


### PR DESCRIPTION
RHEL 7 XFS had a bug in on-disk AGFL (free list) structs.  This was fixed later (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=96f859d).

For RHEL 7 the on-disk structures could not be modified so the kernel was patched to detect the case and do a fix up.

However when virt-v2v runs RHEL 10's xfs_repair on such a filesystem it will be confused by the incorrect AGFL layout and issue an error, which looks like this:
```
  $ xfs_repair -n -P filesystem
  Phase 1 - find and verify superblock...
  Phase 2 - using internal log
          - zero log...
          - scan filesystem freespace and inode maps...
  bad agbno 0 in agfl, agno 11
  freeblk count 7 != flcount 6 in ag 11
  bad agbno 4294967295 in agfl, agno 2
  freeblk count 7 != flcount 6 in ag 2
  sb_fdblocks 390330022, counted 390330024
          - found root inode chunk
  Phase 3 - for each AG...
  [...]
  No modify flag set, skipping filesystem flush and exiting.
  $ echo $?
  1
```
Detect this case using a regexp over the stderr output and ignore it.

Thanks: Sebastian Rodriguez Isaziga
Thanks: Eric Sandeen
Thanks: Brian Foster
Fixes: https://redhat.atlassian.net/browse/RHEL-178287

---
Please take a look: @mnecas @sandeen 
In particular I'm not sure that the technical description of what's happening is correct.