### PR TITLE
passt debug/trace

### DIFF
--- a/lib/guestfs.pod
+++ b/lib/guestfs.pod
@@ -1532,6 +1532,22 @@ On Fedora, install C<kernel-debuginfo> for the C<vmlinux> file
 (containing symbols).  Make sure the symbols precisely match the
 kernel being used.
 
+=head3 passt_log
+
+The direct backend supports:
+
+ export LIBGUESTFS_BACKEND_SETTINGS=passt_log
+
+When this is set, and the direct backend is using C<passt(1)> for
+user-mode networking (see L</guestfs_set_network>), passt is passed
+C<--log-file> pointing at a file inside the per-handle temporary
+directory, so that its debug/trace output (normally lost once passt
+daemonizes into the background) is preserved.  The path of the log
+file is printed via the usual debug channel when
+C<LIBGUESTFS_DEBUG=1> is also set.  Note the log file is removed,
+along with the rest of the temporary directory, when the handle is
+closed.
+
 =head2 ABI GUARANTEE
 
 We guarantee the libguestfs ABI (binary interface), for public,

--- a/lib/launch-direct.c
+++ b/lib/launch-direct.c
@@ -58,6 +58,11 @@ struct backend_direct_data {
   pid_t recoverypid;            /* Recovery process PID. */
 
   char guestfsd_sock[UNIX_PATH_MAX]; /* Path to daemon socket. */
+
+  char *passt_log_path;         /* Path to passt's log file, if the
+                                  * "passt_log" backend setting was
+                                  * used (see launch_passt).  NULL if
+                                  * not applicable. */
 };
 
 /* Helper that sends all output from a command to debug. */
@@ -336,18 +341,24 @@ add_drives (guestfs_h *g, struct backend_direct_data *data,
 /**
  * Launch passt such that it daemonizes.
  *
- * On error, C<-1> is returned; C<passt_pid> and C<sockpath> are not modified.
+ * On error, C<-1> is returned; C<passt_pid>, C<sockpath> and
+ * C<log_path_out> are not modified.
  *
  * On success, C<0> is returned.  C<passt_pid> contains the PID of the passt
  * background process.  C<sockpath> contains the pathname of the unix domain
- * socket where passt will accept a single connection.
+ * socket where passt will accept a single connection.  If the C<passt_log>
+ * backend setting was used, C<*log_path_out> is set to a newly allocated
+ * string containing the path to passt's log file (which the caller now
+ * owns and must free); otherwise it is set to C<NULL>.
  */
 static int
-launch_passt (guestfs_h *g, long *passt_pid, char (*sockpath)[UNIX_PATH_MAX])
+launch_passt (guestfs_h *g, long *passt_pid, char (*sockpath)[UNIX_PATH_MAX],
+             char **log_path_out)
 {
   int rc;
   char sockpath_local[sizeof *sockpath];
   char *pid_path;
+  char *log_path = NULL;
   struct command *cmd;
   int passt_status;
   int passt_exit;
@@ -363,9 +374,16 @@ launch_passt (guestfs_h *g, long *passt_pid, char (*sockpath)[UNIX_PATH_MAX])
   if (pid_path == NULL)
     return rc;
 
+  /* See guestfs.pod / passt_log */
+  if (guestfs_int_get_backend_setting_bool (g, "passt_log") > 0) {
+    log_path = guestfs_int_make_temp_path (g, "passt", "log");
+    if (log_path == NULL)
+      goto free_pid_path;
+  }
+
   cmd = guestfs_int_new_command (g);
   if (cmd == NULL)
-    goto free_pid_path;
+    goto free_log_path;
 
   guestfs_int_cmd_add_arg (cmd, "passt");
   guestfs_int_cmd_add_arg (cmd, "--one-off");
@@ -381,6 +399,15 @@ launch_passt (guestfs_h *g, long *passt_pid, char (*sockpath)[UNIX_PATH_MAX])
   guestfs_int_cmd_add_arg (cmd, NETWORK_GW_MAC);
   guestfs_int_cmd_add_arg (cmd, "--gateway");
   guestfs_int_cmd_add_arg (cmd, NETWORK_GW_IP);
+  if (g->trace)
+    guestfs_int_cmd_add_arg (cmd, "--trace");
+  else if (g->verbose)
+    guestfs_int_cmd_add_arg (cmd, "-d");
+  if (log_path != NULL) {
+    guestfs_int_cmd_add_arg (cmd, "--log-file");
+    guestfs_int_cmd_add_arg (cmd, log_path);
+    debug (g, "passt log file: %s", log_path);
+  }
 
   passt_status = guestfs_int_cmd_run (cmd);
   if (passt_status == -1)
@@ -428,6 +455,8 @@ launch_passt (guestfs_h *g, long *passt_pid, char (*sockpath)[UNIX_PATH_MAX])
   /* We're done. */
   *passt_pid = passt_pid_local;
   ignore_value (strcpy (*sockpath, sockpath_local));
+  *log_path_out = log_path;
+  log_path = NULL;
   rc = 0;
 
 free_pid_str:
@@ -435,6 +464,9 @@ free_pid_str:
 
 close_cmd:
   guestfs_int_cmd_close (cmd);
+
+free_log_path:
+  free (log_path);
 
 free_pid_path:
   free (pid_path);
@@ -761,7 +793,8 @@ launch_direct (guestfs_h *g, void *datav, const char *arg)
     if (guestfs_int_passt_runnable (g)) {
       char passt_sock[UNIX_PATH_MAX];
 
-      if (launch_passt (g, &passt_pid, &passt_sock) == -1)
+      if (launch_passt (g, &passt_pid, &passt_sock,
+                       &data->passt_log_path) == -1)
         goto cleanup0;
 
       start_list ("-netdev") {
@@ -1048,6 +1081,15 @@ launch_direct (guestfs_h *g, void *datav, const char *arg)
  cleanup0:
   if (passt_pid != -1)
     kill (passt_pid, SIGTERM);
+  if (data->passt_log_path != NULL) {
+    CLEANUP_FREE char *log_content = NULL;
+
+    if (guestfs_int_read_whole_file (g, data->passt_log_path,
+                                     &log_content, NULL) == 0)
+      debug (g, "passt log (%s):\n%s", data->passt_log_path, log_content);
+    free (data->passt_log_path);
+    data->passt_log_path = NULL;
+  }
   if (qopts != NULL)
     qemuopts_free (qopts);
   if (daemon_accept_sock >= 0)
@@ -1098,6 +1140,21 @@ shutdown_direct (guestfs_h *g, void *datav, int check_for_errors)
   if (data->guestfsd_sock[0] != '\0') {
     unlink (data->guestfsd_sock);
     data->guestfsd_sock[0] = '\0';
+  }
+
+  /* If we asked passt to keep a log file (see "passt_log" backend
+   * setting), dump its contents to the debug channel now, before the
+   * temporary directory containing it is removed.  By this point qemu
+   * (and therefore, via the "--one-off" socket, passt) has exited.
+   */
+  if (data->passt_log_path != NULL) {
+    CLEANUP_FREE char *log_content = NULL;
+
+    if (guestfs_int_read_whole_file (g, data->passt_log_path,
+                                     &log_content, NULL) == 0)
+      debug (g, "passt log (%s):\n%s", data->passt_log_path, log_content);
+    free (data->passt_log_path);
+    data->passt_log_path = NULL;
   }
 
   return ret;


### PR DESCRIPTION
If LIBGUESTFS_DEBUG=1, pass `-d` to passt; if LIBGUESTFS_TRACE=1, pass also `--trace` to passt. Plus, allow setting passt log, since it cannot print to guestfish output after switch.

An example from output (converted to more readable form):

```
$ perl -pe 's/\\n/\n/g' <<EOF
> libguestfs: passt log (/tmp/libguestfspqwCTC/passt5.log):\npasst 20250415.2340bbf-160000.2.2: /usr/bin/passt.avx2 (408375)\n0.0018: info:    UNIX domain socket bound at /tmp/libguestfs0CX1kH/passt.sock\n0.0019: WARNING: No IPv6 nameserver available for NDP/DHCPv6\n0.0019: info:    Template interface: eno1 (IPv4), eno1 (IPv6)\n0.0019: info:    MAC:\n0.0020: info:        host: 52:56:00:00:00:02\n0.0020: info:        NAT to host 127.0.0.1: 169.254.2.2\n0.0020: info:    DHCP:\n0.0020: info:        assign: 169.254.2.15\n0.0020: info:        mask: 255.255.0.0\n0.0020: info:        router: 169.254.2.2\n0.0020: info:    DNS:\n0.0020: info:        169.254.2.2\n0.0020: info:    DNS search list:\n0.0020: info:        sup.scz.suse.com\n0.0020: info:        example.com\n0.0020: info:    NDP/DHCPv6:\n0.0020: info:        assign: 2001:db8:ca2:2::1\n0.0020: info:        router: ::\n0.0020: info:        our link-local: fe80::5054:ff:fe7f:b37a\n0.0020: info:    DNS search list:\n0.0020: info:        sup.scz.suse.com\n0.0020: info:        example.com\n0.0035: info:    \nYou can now start qemu (>= 7.2, with commit 13c6be96618c):\n0.0035: info:        kvm ... -device virtio-net-pci,netdev=s -netdev stream,id=s,server=off,addr.type=unix,addr.path=/tmp/libguestfs0CX1kH/passt.sock\n0.0035: info:    or qrap, for earlier qemu versions:\n0.0035: info:        ./qrap 5 kvm ... -net socket,fd=5 -net nic,model=virtio\n0.0050:          SO_PEEK_OFF supported\n0.0050:          TCP_INFO tcpi_snd_wnd field  supported\n0.0050:          TCP_INFO tcpi_bytes_acked field  supported\n0.0050:          TCP_INFO tcpi_min_rtt field  supported\n0.0059: ERROR:   epoll_wait() failed in main loop: Invalid argument\n
> EOF
libguestfs: passt log (/tmp/libguestfspqwCTC/passt5.log):
passt 20250415.2340bbf-160000.2.2: /usr/bin/passt.avx2 (408375)
0.0018: info:    UNIX domain socket bound at /tmp/libguestfs0CX1kH/passt.sock
0.0019: WARNING: No IPv6 nameserver available for NDP/DHCPv6
0.0019: info:    Template interface: eno1 (IPv4), eno1 (IPv6)
0.0019: info:    MAC:
0.0020: info:        host: 52:56:00:00:00:02
0.0020: info:        NAT to host 127.0.0.1: 169.254.2.2
0.0020: info:    DHCP:
0.0020: info:        assign: 169.254.2.15
0.0020: info:        mask: 255.255.0.0
0.0020: info:        router: 169.254.2.2
0.0020: info:    DNS:
0.0020: info:        169.254.2.2
0.0020: info:    DNS search list:
0.0020: info:        sup.scz.suse.com
0.0020: info:        example.com
0.0020: info:    NDP/DHCPv6:
0.0020: info:        assign: 2001:db8:ca2:2::1
0.0020: info:        router: ::
0.0020: info:        our link-local: fe80::5054:ff:fe7f:b37a
0.0020: info:    DNS search list:
0.0020: info:        sup.scz.suse.com
0.0020: info:        example.com
0.0035: info:    
You can now start qemu (>= 7.2, with commit 13c6be96618c):
0.0035: info:        kvm ... -device virtio-net-pci,netdev=s -netdev stream,id=s,server=off,addr.type=unix,addr.path=/tmp/libguestfs0CX1kH/passt.sock
0.0035: info:    or qrap, for earlier qemu versions:
0.0035: info:        ./qrap 5 kvm ... -net socket,fd=5 -net nic,model=virtio
0.0050:          SO_PEEK_OFF supported
0.0050:          TCP_INFO tcpi_snd_wnd field  supported
0.0050:          TCP_INFO tcpi_bytes_acked field  supported
0.0050:          TCP_INFO tcpi_min_rtt field  supported
0.0059: ERROR:   epoll_wait() failed in main loop: Invalid argument
```

Should help troubleshooting, instead of editing source directly as proposed at https://github.com/libguestfs/libguestfs/issues/360#issuecomment-4808950392