### PR TITLE
Update the list of appliance packages for Arch Linux

### DIFF
--- a/appliance/packagelist.in
+++ b/appliance/packagelist.in
@@ -118,7 +118,6 @@ ifelse(ARCHLINUX,1,
   nilfs-utils
   ntfs-3g
   ntfsprogs
-  reiserfsprogs
   systemd
   vim
   xz

--- a/appliance/packagelist.in
+++ b/appliance/packagelist.in
@@ -117,7 +117,7 @@ ifelse(ARCHLINUX,1,
   mtools
   nilfs-utils
   ntfs-3g
-  ntfs-3g-system-compression
+  ntfsprogs
   reiserfsprogs
   systemd
   vim

--- a/appliance/packagelist.in
+++ b/appliance/packagelist.in
@@ -110,6 +110,7 @@ ifelse(ARCHLINUX,1,
   grub
   iproute2
   iputils
+  libldm
   linux
   lrzip
   dnl syslinux has mtools as optional dependency, but in reality it's

--- a/appliance/packagelist.in
+++ b/appliance/packagelist.in
@@ -119,6 +119,7 @@ ifelse(ARCHLINUX,1,
   nilfs-utils
   ntfs-3g
   ntfsprogs
+  openssh
   systemd
   systemd-sysvcompat
   vim

--- a/appliance/packagelist.in
+++ b/appliance/packagelist.in
@@ -120,6 +120,7 @@ ifelse(ARCHLINUX,1,
   ntfs-3g
   ntfsprogs
   systemd
+  systemd-sysvcompat
   vim
   xz
   zstd


### PR DESCRIPTION
This change removes the unavailable packages `reiserfsprogs` and `ntfs-3g-system-compression` and adds the `ntfsprogs`, `libldm`, `systemd-sysvcompat` and `openssh` packages for the appliance on Arch Linux.

Fixes https://github.com/libguestfs/libguestfs/issues/362