### PR TITLE
daemon: Fix resource leaks along error paths

### DIFF
--- a/daemon/sh.c
+++ b/daemon/sh.c
@@ -169,18 +169,18 @@ set_up_etc_resolv_conf (struct resolver_state *rs)
   if (lstat (rs->sysroot_etc_resolv_conf, &statbuf) == -1) {
     if (errno != ENOENT) {
       reply_with_perror ("lstat: %s", rs->sysroot_etc_resolv_conf);
-      return -1;
+      goto error;
     }
     /* create empty file */
     fd = open (rs->sysroot_etc_resolv_conf,
                 O_WRONLY|O_CREAT|O_NOCTTY|O_CLOEXEC, 0644);
     if (fd == -1) {
       reply_with_perror ("open: %s", rs->sysroot_etc_resolv_conf);
-      return -1;
+      goto error;
     }
-    if (close(fd) == -1) {
+    if (close (fd) == -1) {
       reply_with_perror ("close: %s", rs->sysroot_etc_resolv_conf);
-      return -1;
+      goto error;
     }
     /* /sysroot/etc/resolv.conf file did not exist, we created it.
      * We remove it using this marker flag after umount.


### PR DESCRIPTION
Found by Coverity:
```
  5. libguestfs-1.58.1/daemon/sh.c:258:5: alloc_arg: "set_up_etc_resolv_conf" allocates memory that is stored into "resolver_state.sysroot_etc_resolv_conf".
  6. libguestfs-1.58.1/daemon/sh.c:160:3: alloc_fn: Storage is returned from allocation function "sysroot_path".
  7. libguestfs-1.58.1/daemon/utils.c:190:3: alloc_fn: Storage is returned from allocation function "malloc".
  8. libguestfs-1.58.1/daemon/utils.c:190:3: assign: Assigning: "r" = "malloc(len)".
  10. libguestfs-1.58.1/daemon/utils.c:194:3: noescape: Resource "r" is not freed or pointed-to in function "snprintf". [Note: The source code implementation of the function has been overridden by a builtin model.]
  11. libguestfs-1.58.1/daemon/utils.c:195:3: return_alloc: Returning allocated memory "r".
  12. libguestfs-1.58.1/daemon/sh.c:160:3: assign: Assigning: "rs->sysroot_etc_resolv_conf" = "sysroot_path("/etc/resolv.conf")".
  19. libguestfs-1.58.1/daemon/sh.c:259:7: noescape: There is at least one path in "free_resolver_state" on which resource "resolver_state.sysroot_etc_resolv_conf" is not freed or pointed-to.
  20. libguestfs-1.58.1/daemon/sh.c:259:7: leaked_storage: Variable "resolver_state" going out of scope leaks the storage "resolver_state.sysroot_etc_resolv_conf" points to.
  #   257|     if (enable_network) {
  #   258|       if (set_up_etc_resolv_conf (&resolver_state) == -1)
  #   259|->       return NULL;
  #   260|     }
  #   261|
```
Fixes: commit 9c3729f7b671e5631b7e7e200228e313bf85e353

@sparimi-rh please review