### PR TITLE
Add guestfs_setfiles optional `excludes` parameter

### DIFF
--- a/daemon/daemon-c.c
+++ b/daemon/daemon-c.c
@@ -116,7 +116,7 @@ guestfs_int_daemon_copy_mountable (const mountable_t *mountable)
   CAMLreturn (r);
 }
 
-/* Implement StringList(...) parameter. */
+/* Implement StringList and OStringList parameters. */
 value
 guestfs_int_daemon_copy_string_list (char * const *strs)
 {

--- a/daemon/selinux.ml
+++ b/daemon/selinux.ml
@@ -44,12 +44,12 @@ let setfiles_has_option =
        Hashtbl.add h flag r;
        r
 
-let setfiles ?(force = false) specfile paths =
+let setfiles ?(force = false) ?(excludes = []) specfile paths =
   if paths = [] then ()
   else (
     (* Prefix /sysroot on all paths. *)
     let ignored_paths =
-      [ "/dev"; "/proc"; "/selinux"; "/sys" ] |>
+      [ "/dev"; "/proc"; "/selinux"; "/sys" ] @ excludes |>
       List.map sysroot_path in
     let specfile = sysroot_path specfile in
     let paths = List.map sysroot_path paths in

--- a/generator/actions_core.ml
+++ b/generator/actions_core.ml
@@ -9571,7 +9571,7 @@ Use C<guestfs_list_dm_devices> to list all device mapper devices.|} };
 
   { defaults with
     name = "setfiles"; added = (1, 57, 1);
-    style = RErr, [String (PlainString, "specfile"); StringList (Pathname, "paths")], [OBool "force"];
+    style = RErr, [String (PlainString, "specfile"); StringList (Pathname, "paths")], [OBool "force"; OStringList "excludes"];
     impl = OCaml "Selinux.setfiles";
     optional = Some "selinuxrelabel";
     test_excuse = "tests are in the tests/relabel directory";
@@ -9592,7 +9592,10 @@ If the list is empty, setfiles is not called.
 
 The optional C<force> boolean controls whether the context
 is reset for customizable files, and also whether the
-user, role and range parts of the file context is changed.|} };
+user, role and range parts of the file context is changed.
+
+The optional C<excludes> list allows you to exclude parts of the
+directory tree by appending the C<setfiles> I<-e> option.|} };
 
   { defaults with
     name = "xfs_info2"; added = (1, 59, 2);

--- a/generator/actions_core_deprecated.ml
+++ b/generator/actions_core_deprecated.ml
@@ -565,7 +565,7 @@ attaches it as a device.|} };
     name = "setcon"; added = (1, 0, 67);
     style = RErr, [String (PlainString, "context")], [];
     optional = Some "selinux";
-    deprecated_by = Replaced_by "selinux_relabel";
+    deprecated_by = Replaced_by "setfiles";
     shortdesc = "set SELinux security context";
     longdesc = "\
 This sets the SELinux security context of the daemon
@@ -577,7 +577,7 @@ See the documentation about SELINUX in L<guestfs(3)>." };
     name = "getcon"; added = (1, 0, 67);
     style = RString (RPlainString, "context"), [], [];
     optional = Some "selinux";
-    deprecated_by = Replaced_by "selinux_relabel";
+    deprecated_by = Replaced_by "setfiles";
     shortdesc = "get SELinux security context";
     longdesc = "\
 This gets the SELinux security context of the daemon.

--- a/generator/actions_properties_deprecated.ml
+++ b/generator/actions_properties_deprecated.ml
@@ -64,7 +64,7 @@ return the default qemu binary name." };
     style = RErr, [Bool "selinux"], [];
     fish_alias = ["selinux"]; config_only = true;
     blocking = false;
-    deprecated_by = Replaced_by "selinux_relabel";
+    deprecated_by = Replaced_by "setfiles";
     shortdesc = "set SELinux enabled or disabled at appliance boot";
     longdesc = {|This sets the selinux flag that is passed to the appliance
 at boot time.  The default is C<selinux=0> (disabled).
@@ -79,7 +79,7 @@ see L<guestfs(3)>.|} };
     name = "get_selinux"; added = (1, 0, 67);
     style = RBool "selinux", [], [];
     blocking = false;
-    deprecated_by = Replaced_by "selinux_relabel";
+    deprecated_by = Replaced_by "setfiles";
     shortdesc = "get SELinux enabled flag";
     longdesc = {|This returns the current setting of the selinux flag which
 is passed to the appliance at boot time.  See C<guestfs_set_selinux>.

--- a/generator/daemon.ml
+++ b/generator/daemon.ml
@@ -807,7 +807,8 @@ let generate_daemon_caml_stubs () =
               pr "caml_copy_int64 (%s)" n
            | OString _ ->
               pr "caml_copy_string (%s)" n
-           | OStringList _ -> assert false
+           | OStringList _ ->
+              pr "guestfs_int_daemon_copy_string_list (%s)" n
           );
           pr ";\n";
           pr "    args[%d] = caml_alloc (1, 0);\n" !i;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -748,8 +748,14 @@ regressions_test_big_heap_LDADD = \
 SLOW_TESTS += regressions/rhbz909624.sh
 EXTRA_DIST += regressions/rhbz909624.sh
 
-TESTS += relabel/test-relabel.py
-EXTRA_DIST += relabel/test-relabel.py
+TESTS += \
+	relabel/test-relabel.py \
+	relabel/test-setfiles.py \
+	$(NULL)
+EXTRA_DIST += \
+	relabel/test-relabel.py \
+	relabel/test-setfiles.py \
+	$(NULL)
 
 # Test relative paths to backing files.  Mainly this is a test that we
 # don't break this.

--- a/tests/relabel/test-setfiles.py
+++ b/tests/relabel/test-setfiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2025 Red Hat Inc.
+# Copyright (C) 2025-2026 Red Hat Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# Test the deprecated selinux_relabel function.
+# Test the setfiles function.
 
 import os
 import sys
@@ -25,7 +25,7 @@ prog = os.path.basename(sys.argv[0])
 # Because we parse error message strings below.
 os.environ["LANG"] = "C"
 
-if os.environ.get("SKIP_TEST_RELABEL_PY"):
+if os.environ.get("SKIP_TEST_SETFILES_PY"):
     print(f"{prog}: test skipped because environment variable is set.")
     sys.exit(77)
 
@@ -79,7 +79,7 @@ g.write("/etc/file_contexts", """/.* system_u:object_r:default_t:s0
 """)
 
 # Do the relabel.
-g.selinux_relabel("/etc/file_contexts", "/", force=True)
+g.setfiles("/etc/file_contexts", "/", force=True)
 
 # Check the labels were set correctly.
 errors = 0

--- a/tests/relabel/test-setfiles.py
+++ b/tests/relabel/test-setfiles.py
@@ -62,6 +62,8 @@ g.mount_options("user_xattr", "/dev/sda1", "/")
 g.mkdir("/bin")
 g.touch("/bin/ls")
 g.mkdir("/etc")
+g.mkdir("/lib")
+g.touch("/lib/libc.so")
 g.mkdir("/tmp")
 g.touch("/tmp/test")
 g.mkdir("/var")
@@ -75,13 +77,14 @@ g.write("/etc/file_contexts", """/.* system_u:object_r:default_t:s0
 /bin/.* system_u:object_r:bin_t:s0
 /etc/.* system_u:object_r:etc_t:s0
 /etc/file_contexts <<none>>
+/lib/.* system_u:object_r:lib_t:s0
 /tmp/.* <<none>>
 /var/.* system_u:object_r:var_t:s0
 /var/log/.* system_u:object_r:var_log_t:s0
 """)
 
 # Do the relabel.
-g.setfiles("/etc/file_contexts", "/", force=True)
+g.setfiles("/etc/file_contexts", "/", force=True, excludes=["/lib", "/lib64"])
 
 # Check the labels were set correctly.
 errors = 0
@@ -122,6 +125,8 @@ check_label("/bin", "system_u:object_r:default_t:s0")
 check_label("/bin/ls", "system_u:object_r:bin_t:s0")
 check_label("/etc", "system_u:object_r:default_t:s0")
 check_label_none("/etc/file_contexts")
+check_label_none("/lib") # because /lib in excludes
+check_label_none("/lib/libc.so") # because /lib in excludes
 check_label("/tmp", "system_u:object_r:default_t:s0")
 check_label_none("/tmp/test")
 check_label("/var", "system_u:object_r:default_t:s0")

--- a/tests/relabel/test-setfiles.py
+++ b/tests/relabel/test-setfiles.py
@@ -37,6 +37,8 @@ if not os.path.isfile("/etc/selinux/config") or not os.access("/usr/sbin/load_po
 
 # Create a filesystem.
 g = guestfs.GuestFS(python_return_dict=True)
+g.set_verbose(True)
+g.set_trace(True)
 g.add_drive_scratch(256 * 1024 * 1024)
 g.launch()
 


### PR DESCRIPTION
In some virt-v2v conversions, `setfiles` can take a very long time.  It's suspected this is because it gets "bogged down" in certain irrelevant directories, eg. `/var/lib/containerd`.  Since these directories are never touched by v2v conversions it should be safe to exclude them by passing additional `-e` options to `setfiles`.

While we are still collecting additional information from customers about the v2v cases, add the infrastructure to libguestfs to allow directory excludes to be passed to `setfiles`.