### PR TITLE
generator/customize.ml: Add `--selinux-relabel-exclude` flag

### DIFF
--- a/generator/customize.ml
+++ b/generator/customize.ml
@@ -598,6 +598,8 @@ type flag = {
 and flag_type =
 | FlagBool of bool                   (* boolean, with default value *)
 | FlagPasswordCrypto of string
+| FlagStringMultiple of string       (* string, may be used multiple times
+                                        to build a list *)
 
 let flags = [
   { flag_name = "no-logfile";
@@ -719,6 +721,8 @@ let rec argspec ?(v2v = false) () =
       pr "  let %s = ref %b in\n" var default
     | { flag_type = FlagPasswordCrypto _; flag_ml_var = var } ->
       pr "  let %s = ref None in\n" var
+    | { flag_type = FlagStringMultiple _; flag_ml_var = var } ->
+      pr "  let %s = ref [] in\n" var
   ) flags;
   pr {|
   let rec get_ops () = {
@@ -921,6 +925,17 @@ let rec argspec ?(v2v = false) () =
       pr "      s_\"%s\"\n" shortdesc;
       pr "    ),\n";
       pr "    Some %S, %S, false;\n" v longdesc
+    | { flag_type = FlagStringMultiple v; flag_ml_var = var; flag_name = name;
+        flag_shortdesc = shortdesc; flag_pod_longdesc = longdesc } ->
+      pr "    (\n";
+      pr "      [ L\"%s\" ],\n" name;
+      pr "      Getopt.String (\n";
+      pr "        s_\"%s\",\n" v;
+      pr "        List.push_back %s\n" var;
+      pr "      ),\n";
+      pr "      s_\"%s\"\n" shortdesc;
+      pr "    ),\n";
+      pr "    Some %S, %S, false;\n" v longdesc
   ) flags;
 
   pr "  ]
@@ -1044,6 +1059,9 @@ and generate_ops_struct_decl () =
         flag_name = name } ->
       pr "  %s : Password.password_crypto option;\n      (* --%s %s *)\n"
         var name v
+    | { flag_type = FlagStringMultiple _; flag_ml_var = var;
+        flag_name = name } ->
+      pr "  %s : string list;\n      (* --%s *)\n" var name
   ) flags;
   pr "}\n"
 
@@ -1067,6 +1085,8 @@ let generate_customize_synopsis_pod ?(v2v = false) () =
         | { flag_type = FlagBool _; flag_name = n } ->
           n, sprintf "[--%s]" n
         | { flag_type = FlagPasswordCrypto v; flag_name = n } ->
+          n, sprintf "[--%s %s]" n v
+        | { flag_type = FlagStringMultiple v; flag_name = n } ->
           n, sprintf "[--%s %s]" n v
       ) flags in
 
@@ -1110,6 +1130,9 @@ let generate_customize_options_pod ?(v2v = false) () =
         | { flag_type = FlagBool _; flag_name = n; flag_pod_longdesc = ld } ->
           n, sprintf "B<--%s>" n, ld
         | { flag_type = FlagPasswordCrypto v;
+            flag_name = n; flag_pod_longdesc = ld } ->
+          n, sprintf "B<--%s> %s" n v, ld
+        | { flag_type = FlagStringMultiple v;
             flag_name = n; flag_pod_longdesc = ld } ->
           n, sprintf "B<--%s> %s" n v, ld
       ) flags in

--- a/generator/customize.ml
+++ b/generator/customize.ml
@@ -661,6 +661,25 @@ The option is a no-op for guests that do not support SELinux.|};
     flag_pod_longdesc = "This is a compatibility option that does nothing.";
   };
 
+  { flag_name = "selinux-relabel-exclude";
+    flag_type = FlagStringMultiple "DIR";
+    flag_ml_var = "selinux_relabel_excludes";
+    flag_shortdesc = "Exclude directories from SELinux relabelling";
+    flag_pod_longdesc = {|Exclude directories from being relabelled.
+
+This advanced option lets you list directories in the guest which
+should not be relabelled, even when SELinux relabelling is
+enabled.  Use this carefully, as any changes that are made
+inside these directories during customization will have incorrect
+SELinux labels, leading to potential failures later, so you must
+be sure that the directories do not need relabelling.
+
+If in doubt, do not use this option.
+
+You can pass the option multiple times, eg.
+I<--selinux-relabel-exclude=/foo> I<--selinux-relabel-exclude=/bar>|};
+  };
+
 ]
 
 let rec generate_customize_cmdline_mli () =


### PR DESCRIPTION
This can be used to specify a list of directories which are excluded during SELinux relabelling.

The purpose of this is as an advanced option to allow relabelling to skip specific directories that contain millions of files, where we can be sure that (eg) virt-v2v did not update any files in that directory. Thus greatly reducing relabelling time.  Virt-v2v will also include a built-in list of directories to exclude that are known problematic, but the general list is unknowable since guests may have arbitrary filesystems, hence why this flag is needed for advanced users.

Fixes: https://redhat.atlassian.net/browse/RHEL-222316

----

Note that this commit updates generated files in the common submodule.  It doesn't actually change libguestfs code.