### PR TITLE
daemon/rpm-c.c: Fix non-librpm path

### DIFF
--- a/daemon/rpm-c.c
+++ b/daemon/rpm-c.c
@@ -48,30 +48,32 @@
 
 #ifndef HAVE_LIBRPM
 
-value __attribute__((noreturn))
+value /* __attribute__((noreturn)) - GCC warns about return statement */
 guestfs_int_daemon_rpm_init (value unitv)
 {
   CAMLparam1 (unitv);
   caml_failwith ("no support for RPM guests because "
                  "librpm was missing at compile time");
+  /*NOTREACHED*/
+  CAMLreturn (Val_unit);
 }
 
 value __attribute__((noreturn))
 guestfs_int_daemon_rpm_start_iterator (value unitv)
 {
-  guestfs_int_daemon_rpm_init (unitv);
+  abort ();
 }
 
 value __attribute__((noreturn))
 guestfs_int_daemon_rpm_next_application (value unitv)
 {
-  guestfs_int_daemon_rpm_init (unitv);
+  abort ();
 }
 
 value __attribute__((noreturn))
 guestfs_int_daemon_rpm_end_iterator (value unitv)
 {
-  guestfs_int_daemon_rpm_init (unitv);
+  abort ();
 }
 
 #else /* HAVE_LIBRPM */


### PR DESCRIPTION
The code on the non-librpm path was copy and pasted and completely wrong.  The rpm_init function had an unmatched CAMLparam resulting in this warning (when `./configure --enable-werror`):
```
  In file included from rpm-c.c:31:
  rpm-c.c: In function ‘guestfs_int_daemon_rpm_init’:
  /usr/lib64/ocaml/caml/memory.h:302:29: error: unused variable ‘caml__frame’ [-Werror=unused-variable]
    302 |   struct caml__roots_block *caml__frame = *caml_local_roots_ptr
        |                             ^~~~~~~~~~~
  /usr/lib64/ocaml/caml/memory.h:305:3: note: in expansion of macro ‘CAMLparam0’
    305 |   CAMLparam0 (); \
        |   ^~~~~~~~~~
  rpm-c.c:54:3: note: in expansion of macro ‘CAMLparam1’
     54 |   CAMLparam1 (unitv);
        |   ^~~~~~~~~~
```
Actually fixing this while still enabling warnings is quite hard. I had to drop the `noreturn` attribute from the function, otherwise GCC warns about the return statement even though it is unreachable.

Even using `__builtin_unreachable()`/`unreachable()` (C23) doesn't help. I wonder if this is a compiler bug?

Since `rpm_init` throws a Failure, the other functions cannot be reached so we can use `abort`.

Reported-by: Srihari Parimi
Fixes: commit c9ee831affed55abe0f928134cbbd2ed83b2f510